### PR TITLE
CSS で font-family を指定

### DIFF
--- a/viewer/front/app.less
+++ b/viewer/front/app.less
@@ -6,6 +6,9 @@ html, body, #app {
 }
 body {
   margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Hiragino Sans', 'ヒラギノ角ゴシック', 'ヒラギノ角ゴ ProN W3',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   font-size: 15px;
 }
 p {


### PR DESCRIPTION
現在の CSS では、`font-family` が指定されていません。良心的な現代のブラウザではそれでも見た目に問題はありませんが、Safari というブラウザの場合、macOS/iOS 双方で、セリフ体/明朝体のフォントで表示されてしまうため、可読性に難が生じてしまいます。
そこで、`font-family` をテキトーに設定しました。
テキトーなので、問題があればご指摘ください。

なお、この変更は実際に効くかのテストを行っていません。どうせこれでええやろと思って出しましたが、誤っていたらすいません。