### PR TITLE
Upgrade to elasticsearch 7

### DIFF
--- a/connector/Dockerfile
+++ b/connector/Dockerfile
@@ -1,10 +1,10 @@
-FROM alpine:3.9
+FROM rwynn/monstache:6.7.1
 
-RUN apk add --update python3 py3-pip mongodb bash curl && \
-	python3 -m pip install 'mongo-connector[elastic5]' 'elastic2-doc-manager[elastic5]' && \
+RUN apk add --no-cache bash curl && \
 	wget https://github.com/vishnubob/wait-for-it/raw/master/wait-for-it.sh && \
 	chmod +x wait-for-it.sh
 
 COPY run.sh .
+COPY monstache.toml .
 
-CMD ./wait-for-it.sh mongo:27017 -t 0 -- ./wait-for-it.sh elasticsearch:9200 -t 0 -- bash run.sh
+ENTRYPOINT ./wait-for-it.sh mongo:27017 -t 0 -- ./wait-for-it.sh elasticsearch:9200 -t 0 -- bash run.sh

--- a/connector/monstache.toml
+++ b/connector/monstache.toml
@@ -1,0 +1,5 @@
+elasticsearch-max-conns = 2
+elasticsearch-retry = true
+direct-read-split-max = 2
+resume = true
+direct-read-stateful = true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
     container_name: slack-patron-logger
     volumes:
       - .:/usr/local/slack-patron
-    depends_on:
-      - connector
     restart: always
 
   viewer:
@@ -18,16 +16,16 @@ services:
     container_name: slack-patron-viewer
     volumes:
       - .:/usr/local/slack-patron
-    depends_on:
-      - connector
     ports:
       - "127.0.0.1:9292:9292"
     restart: always
 
   connector:
     build: connector
-    volumes:
-      - oplog:/var/log/mongo-connector
+    environment:
+      - MONSTACHE_DIRECT_READ_NS=slack_logger.messages
+      - MONSTACHE_ES_URLS=http://elasticsearch:9200
+      - MONSTACHE_MONGO_URL=mongodb://mongo:27017
     depends_on:
       - mongo
       - elasticsearch
@@ -36,7 +34,8 @@ services:
   elasticsearch:
     build: elasticsearch
     environment:
-      - ES_JAVA_OPTS=-Xms500m -Xmx500m
+      - ES_JAVA_OPTS=-Xms640m -Xmx640m
+      - discovery.type=single-node
     volumes:
       - esdata:/usr/share/elasticsearch/data
     restart: always
@@ -46,6 +45,8 @@ services:
     command: --profile=1 --slowms=100 --bind_ip_all --replSet rs0
     volumes:
       - mongodata:/data/db
+    ports:
+      - "127.0.0.1:27017:27017"
     restart: always
 
 volumes:

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,3 +1,3 @@
-FROM elasticsearch:5.3
+FROM elasticsearch:7.9.3
 RUN elasticsearch-plugin install analysis-kuromoji
 RUN elasticsearch-plugin install analysis-icu

--- a/viewer/viewer.rb
+++ b/viewer/viewer.rb
@@ -73,7 +73,7 @@ def search(params)
     lte: params[:max_ts],
   }
 
-  uri = URI.parse('http://elasticsearch:9200/slack_logger/messages/_search')
+  uri = URI.parse('http://elasticsearch:9200/slack_logger.messages/_search')
   http = Net::HTTP.new(uri.host, uri.port)
   query = {
     query: {
@@ -118,7 +118,9 @@ def search(params)
       message
     end
     all_messages = all_messages.reverse if ts_direction == 'desc'
-    return all_messages, res_data['hits']['total'] > limit
+    # FIXME: The meaning of hits.total.value might change in ElasticSearch 8
+    # https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#hits-total-now-object-search-response
+    return all_messages, res_data['hits']['total']['value'] > limit
   else
     return [], false
   end


### PR DESCRIPTION
Additional changes required for upgrade (already executed for tsg-ut server):
- Set [sysctl](https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html)
- Wipe elasticsearch volume (to create the index from scratch)