### PR TITLE
Fix mongo not found error on connector container

### DIFF
--- a/connector/Dockerfile
+++ b/connector/Dockerfile
@@ -1,10 +1,19 @@
-FROM rwynn/monstache:6.7.1
+FROM mongo:4.4.2
 
-RUN apk add --no-cache bash curl && \
-	wget https://github.com/vishnubob/wait-for-it/raw/master/wait-for-it.sh && \
-	chmod +x wait-for-it.sh
+RUN apt-get update -y && \
+	apt-get install wget zip -y && \
+	cd /tmp && \
+	wget https://github.com/rwynn/monstache/releases/download/v6.7.3/monstache-b9dcddc.zip && \
+	unzip monstache-b9dcddc.zip && \
+	mv build/linux-amd64/monstache /bin && \
+	wget https://github.com/vishnubob/wait-for-it/raw/master/wait-for-it.sh -O /wait-for-it.sh && \
+	chmod +x /wait-for-it.sh && \
+	apt-get purge wget zip -y && \
+	apt-get autoremove -y && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/* /tmp
 
 COPY run.sh .
 COPY monstache.toml .
 
-ENTRYPOINT ./wait-for-it.sh mongo:27017 -t 0 -- ./wait-for-it.sh elasticsearch:9200 -t 0 -- bash run.sh
+ENTRYPOINT /wait-for-it.sh mongo:27017 -t 0 -- /wait-for-it.sh elasticsearch:9200 -t 0 -- bash run.sh

--- a/connector/Dockerfile
+++ b/connector/Dockerfile
@@ -1,7 +1,7 @@
 FROM mongo:4.4.2
 
 RUN apt-get update -y && \
-	apt-get install wget zip -y && \
+	apt-get install wget zip curl -y && \
 	cd /tmp && \
 	wget https://github.com/rwynn/monstache/releases/download/v6.7.3/monstache-b9dcddc.zip && \
 	unzip monstache-b9dcddc.zip && \

--- a/connector/Dockerfile
+++ b/connector/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update -y && \
 	apt-get purge wget zip -y && \
 	apt-get autoremove -y && \
 	apt-get clean && \
-	rm -rf /var/lib/apt/lists/* /tmp
+	rm -rf /var/lib/apt/lists/* /tmp/*
 
 COPY run.sh .
 COPY monstache.toml .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     restart: always
 
   mongo:
-    image: mongo
+    image: mongo:4.4.2
     command: --profile=1 --slowms=100 --bind_ip_all --replSet rs0
     volumes:
       - mongodata:/data/db


### PR DESCRIPTION
#13 のマージ以降connectorコンテナにmongoバイナリがインストールされてないためにrun.shが失敗し、レプリケーションがinitializeされず他コンテナからMongoDBに接続できない問題を修正。

むしろなんで今まで動いてたんだ🤔