### PR TITLE
Slack Events API対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,5 @@ end
 
 gem "slack-ruby-client"
 gem "async-websocket", '~> 0.8.0' # dependency of slack-ruby-client RTM
+
+gem "rack", "~> 2.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1305,6 +1305,7 @@ DEPENDENCIES
   mongo
   nokogiri
   puma
+  rack (~> 2.2)
   rubyzip
   sinatra
   slack-ruby-client

--- a/bin/init.rb
+++ b/bin/init.rb
@@ -5,7 +5,10 @@ require 'securerandom'
 # XXX using string hash key for backword compatibility...
 config = {
   'slack' => {
-    'token' => nil
+    'token' => nil,
+    'team_id' => nil,
+    'events_api' => false,
+    'signing_secret' => nil,
   },
   'aws' => {
     'access_key_id' => nil,

--- a/bin/init.rb
+++ b/bin/init.rb
@@ -7,7 +7,7 @@ config = {
   'slack' => {
     'token' => nil,
     'team_id' => nil,
-    'events_api' => false,
+    'use_events_api' => false,
     'signing_secret' => nil,
   },
   'aws' => {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - .:/usr/local/slack-patron
     ports:
-      - "127.0.0.1:9293:9292"
+      - "127.0.0.1:9293:9293"
     restart: always
 
   viewer:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     container_name: slack-patron-logger
     volumes:
       - .:/usr/local/slack-patron
+    ports:
+      - "127.0.0.1:9293:9292"
     restart: always
 
   viewer:

--- a/lib/slack.rb
+++ b/lib/slack.rb
@@ -11,3 +11,7 @@ Slack::RealTime::Client.configure do |c|
   c.start_method = :rtm_connect
   c.store_class = Slack::RealTime::Stores::Starter
 end
+
+Slack::Events.configure do |c|
+  c.signing_secret = config['slack']&.[]('events_api')&.[]('signing_secret')
+end

--- a/lib/slack.rb
+++ b/lib/slack.rb
@@ -13,5 +13,5 @@ Slack::RealTime::Client.configure do |c|
 end
 
 Slack::Events.configure do |c|
-  c.signing_secret = config['slack']['events_api'] ? config['slack']['signing_secret'] : nil
+  c.signing_secret = config['slack']['use_events_api'] ? config['slack']['signing_secret'] : nil
 end

--- a/lib/slack.rb
+++ b/lib/slack.rb
@@ -13,5 +13,5 @@ Slack::RealTime::Client.configure do |c|
 end
 
 Slack::Events.configure do |c|
-  c.signing_secret = config['slack']&.[]('events_api')&.[]('signing_secret')
+  c.signing_secret = config['slack']['events_api'] ? config['slack']['signing_secret'] : nil
 end

--- a/lib/slack_events_receiver.rb
+++ b/lib/slack_events_receiver.rb
@@ -1,0 +1,83 @@
+require 'rack'
+
+class SlackEventsReceiver
+  attr_reader :logger
+
+  def initialize(team_id)
+    @team_id = team_id
+    raise ArgumentError unless @team_id and @team_id.start_with? 'T'
+  end
+
+  def start!(logger)
+    @logger = logger
+
+    Rack::Server.start(
+      app: lambda do |env|
+        req = Rack::Request.new(env)
+
+        begin
+          Slack::Events::Request.new(req).verify!
+          process(req.body)
+        rescue Slack::Events::Request::MissingSigningSecret,
+          Slack::Events::Request::InvalidSignature,
+          Slack::Events::Request::TimestampExpired => e
+          warn 'bad request: %s' % e
+          [400, {}, '']
+        end
+      end
+    )
+  end
+
+  def process(body)
+    # https://api.slack.com/apis/connections/events-api
+
+    data = JSON.parse(body.read)
+    type = data['type']
+
+    case type
+    when 'url_verification'
+      [200, { 'content-type': 'text/plain' }, data['challenge']]
+    when 'event_callback'
+      process_event data['event'] if data['team_id'] == @team_id
+      [204, {}, '']
+    else
+      [400, {}, '']
+    end
+  end
+
+  def process_event(event)
+    type = event['type']
+    event.delete 'type'
+
+    case type
+    when 'message'
+      # https://api.slack.com/events/message
+      return if logger.is_private_channel(event['channel'])
+      return if logger.is_direct_message(event['channel'])
+
+      puts 'new message'
+
+      logger.insert_message(event)
+
+    when 'team_join'
+      puts 'new user has joined'
+      logger.update_users
+
+    when 'user_change'
+      puts 'user data has changed'
+      logger.update_users
+
+    when 'channel_created'
+      puts 'channel has created'
+      logger.update_channels
+
+    when 'channel_rename'
+      puts 'channel has renamed'
+      logger.update_channels
+
+    when 'emoji_changed'
+      puts 'emoji has changed'
+      logger.update_emojis
+    end
+  end
+end

--- a/lib/slack_events_receiver.rb
+++ b/lib/slack_events_receiver.rb
@@ -24,7 +24,8 @@ class SlackEventsReceiver
           warn 'bad request: %s' % e
           [400, {}, '']
         end
-      end
+      end,
+      Port: 9293,
     )
   end
 

--- a/lib/slack_rtm_receiver.rb
+++ b/lib/slack_rtm_receiver.rb
@@ -1,0 +1,50 @@
+class SlackRTMReceiver
+  def start!(logger)
+    realtime = Slack::RealTime::Client.new
+
+    realtime.on :message do |m|
+      if logger.is_private_channel(m['channel'])
+        next
+      end
+      if logger.is_direct_message(m['channel'])
+        next
+      end
+
+      puts m
+      logger.insert_message(m)
+    end
+
+    realtime.on :team_join do |e|
+      puts "new user has joined"
+      logger.update_users
+    end
+
+    realtime.on :user_change do |e|
+      puts "user data has changed"
+      logger.update_users
+    end
+
+    realtime.on :channel_created do |c|
+      puts "channel has created"
+      logger.update_channels
+    end
+
+    realtime.on :channel_rename do |c|
+      puts "channel has renamed"
+      logger.update_channels
+    end
+
+    realtime.on :emoji_changed do |c|
+      puts "emoji has changed"
+      logger.update_emojis
+    end
+
+    # if connection closed, restart the realtime logger
+    realtime.on :close do
+      puts "websocket disconnected"
+      start!
+    end
+
+    realtime.start!
+  end
+end

--- a/lib/slack_rtm_receiver.rb
+++ b/lib/slack_rtm_receiver.rb
@@ -10,7 +10,7 @@ class SlackRTMReceiver
         next
       end
 
-      puts m
+      puts 'new message'
       logger.insert_message(m)
     end
 
@@ -42,7 +42,7 @@ class SlackRTMReceiver
     # if connection closed, restart the realtime logger
     realtime.on :close do
       puts "websocket disconnected"
-      start!
+      start! logger
     end
 
     realtime.start!

--- a/logger/logger.rb
+++ b/logger/logger.rb
@@ -1,3 +1,10 @@
-require './lib/slack_logger'
+require './lib/slack'
 
-SlackLogger.new.start
+require './lib/slack_logger'
+require './lib/slack_events_receiver'
+require './lib/slack_rtm_receiver'
+
+config = YAML.load_file('./config.yml')
+
+receiver = Slack::Events.config.signing_secret ? SlackEventsReceiver.new(config['slack']['team_id']) : SlackRTMReceiver.new
+SlackLogger.new.start receiver

--- a/logger/logger.rb
+++ b/logger/logger.rb
@@ -6,5 +6,5 @@ require './lib/slack_rtm_receiver'
 
 config = YAML.load_file('./config.yml')
 
-receiver = Slack::Events.config.signing_secret ? SlackEventsReceiver.new(config['slack']['team_id']) : SlackRTMReceiver.new
+receiver = config['slack']['event_api'] ? SlackEventsReceiver.new(config['slack']['team_id']) : SlackRTMReceiver.new
 SlackLogger.new.start receiver

--- a/logger/logger.rb
+++ b/logger/logger.rb
@@ -6,5 +6,5 @@ require './lib/slack_rtm_receiver'
 
 config = YAML.load_file('./config.yml')
 
-receiver = config['slack']['event_api'] ? SlackEventsReceiver.new(config['slack']['team_id']) : SlackRTMReceiver.new
+receiver = config['slack']['use_events_api'] ? SlackEventsReceiver.new(config['slack']['team_id']) : SlackRTMReceiver.new
 SlackLogger.new.start receiver


### PR DESCRIPTION
Resolve https://github.com/tsg-ut/slack-patron/issues/27

たぶん動くと思うっす

https://api.slack.com/apis/connections/events-api

config.ymlに以下を設定すると動きます: 
* `slack.team_id`: Tではじまるteam id。RTMと違ってEvents APIは全teamのが混ざってくるので
* `slack.use_events_api` : events_apiモードにしたかったらtruthyなものを指定してね
* `slack.signing_secret`: Signing Secret。

`slack.use_events_api` の値によって、Events APIモードにするか、旧来のRTMモードになるかが変わります。

`docker-compose.yml`の内容的に、9293 portにEvents APIが来るとloggerに渡って処理される感じになっています