### PR TITLE
Section Block のレンダリングを一部実装

### DIFF
--- a/viewer/front/components/message/Attachment.js
+++ b/viewer/front/components/message/Attachment.js
@@ -62,6 +62,24 @@ class Footer extends Component {
   }
 }
 
+class Fields extends Component {
+  render() {
+    const {fields} = this.props;
+    return (
+      <div className="attachment-fields">
+        {
+          fields.map((field, index) => (
+            <div key={index} className="attachment-field">
+              <div className="attachment-field-title">{field.title}</div>
+              <div className="attachment-field-value">{field.value}</div>
+            </div>
+          ))
+        }
+      </div>
+    );
+  }
+}
+
 export default class extends Component {
   render() {
     const {attachment} = this.props;
@@ -92,16 +110,7 @@ export default class extends Component {
               </div>
             )}
             {attachment.fields && (
-              <div className="attachment-fields">
-                {
-                  attachment.fields.map((field, index) => (
-                    <div key={index} className="attachment-field">
-                      <div className="attachment-field-title">{field.title}</div>
-                      <div className="attachment-field-value">{field.value}</div>
-                    </div>
-                  ))
-                }
-              </div>
+              <Fields fields={attachment.fields} />
             )}
             {(attachment.footer || attachment.footer_icon || attachment.ts) && (
               <Footer text={attachment.footer} icon={attachment.footer_icon} ts={attachment.ts}/>

--- a/viewer/front/components/message/Block.js
+++ b/viewer/front/components/message/Block.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import Emoji from './Emoji';
+import Element, { Text } from './Element';
 import UserMention from './UserMention';
 import ChannelMention from './ChannelMention';
 
@@ -154,6 +155,36 @@ class RichTextBlock extends Component {
   }
 }
 
+class SectionBlock extends Component {
+  render() {
+    const {text, fields, accessory} = this.props;
+
+    return (
+      <div className="section-block">
+        <div className="section-block-body">
+          <div className="section-block-text">
+            <Text text={text} />
+          </div>
+          {fields && fields.length > 0 && (
+            <div className="section-block-fields">
+              {fields.map((field, index) => (
+                <div key={index} className="section-block-field">
+                  <Text text={field} />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+        {accessory && (
+          <div className="section-block-accessory">
+            <Element element={accessory} />
+          </div>
+        )}
+      </div>
+    );
+  }
+}
+
 export default class extends Component {
   constructor(props) {
     super(props);
@@ -169,6 +200,7 @@ export default class extends Component {
   }
   render() {
     const {block} = this.props;
+
     if (block.type === 'rich_text') {
       return (
         <div className="slack-message-block">
@@ -176,11 +208,20 @@ export default class extends Component {
         </div>
       )
     }
+
+    // https://api.slack.com/reference/block-kit/blocks#section
+    if (block.type === 'section') {
+      return (
+        <div className="slack-message-block">
+          <SectionBlock text={block.text} fields={block.fields} accessory={block.accessory} />
+        </div>
+      )
+    }
+
     return (
       <div className="slack-message-block">
-        {/* TODO */}
         <div className="slack-message-unsupported-block" onClick={this.handleToggleRawData}>
-          ⚠️未対応のブロック (クリックで生データ表示)
+          ⚠️ Unsupported block (click to show raw data)
         </div>
         { !this.state.isHidden && (
           <pre className="slack-message-block-raw">

--- a/viewer/front/components/message/Block.less
+++ b/viewer/front/components/message/Block.less
@@ -75,3 +75,37 @@
     border-radius: 0.25rem;
   }
 }
+
+.section-block {
+  margin-bottom: 8px;
+
+  display: flex;
+  @media @mobile {
+    flex-direction: column;
+  }
+
+  .section-block-body {
+    flex: 1 1 0;
+  }
+
+  .section-block-accessory {
+    flex: 0 0 auto;
+
+    @media @mobile {
+      margin-top: 4px;
+    }
+  }
+
+  .section-block-fields {
+    margin-top: 4px;
+    display: flex;
+    flex-wrap: wrap;
+    width: 100%;
+    max-width: 400px;
+
+    .section-block-field {
+      flex: 0 0 50%;
+      margin: 0.1rem 0;
+    }
+  }
+}

--- a/viewer/front/components/message/Element.js
+++ b/viewer/front/components/message/Element.js
@@ -1,0 +1,68 @@
+import React, { Component } from 'react';
+import MrkdwnText from './MrkdwnText';
+
+import './Element.less';
+
+export class Text extends Component {
+  render() {
+    const {text} = this.props;
+    if (text.type === 'mrkdwn') {
+      return <MrkdwnText text={text.text} />;
+    }
+    if (text.type === 'plain_text') {
+      return <span className="plain-text">{text.text}</span>;
+    }
+    return (
+      <span style={{color: 'red'}}>
+        ERROR: Unsupported text type: {text.type}
+      </span>
+    );
+  }
+}
+
+export default class extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isHidden: true,
+    };
+    this.handleToggleRawData = this.handleToggleRawData.bind(this);
+  }
+
+  handleToggleRawData() {
+    this.setState((state) => ({
+      isHidden: !state.isHidden,
+    }));
+  }
+
+  render() {
+    const {element} = this.props;
+
+    if (element.type === 'button') {
+      return (
+        <span className="slack-message-element">
+          <button
+            className={`slack-message-button slack-message-button-${element.style || 'default'}`}
+            onClick={this.props.onClick}
+            disabled
+          >
+            <Text text={element.text} />
+          </button>
+        </span>
+      );
+    }
+
+    return (
+      <span className="slack-message-element">
+        <div className="slack-message-unsupported-element" onClick={this.handleToggleRawData}>
+          ⚠️ Unsupported element (click to show raw data)
+        </div>
+        { !this.state.isHidden && (
+          <pre className="slack-message-element-raw">
+            {JSON.stringify(element, null, '  ')}
+          </pre>
+        ) }
+      </span>
+    );
+  }
+}

--- a/viewer/front/components/message/Element.less
+++ b/viewer/front/components/message/Element.less
@@ -1,0 +1,45 @@
+.slack-message-unsupported-element {
+  display: inline-block;
+  background: #ffeb3b;
+  color: #a1952a;
+  font-size: 0.8em;
+  line-height: 0.8em;
+  padding: 0.3rem;
+  margin-bottom: 0.6rem;
+  border-radius: 3px;
+  cursor: pointer;
+}
+
+.slack-message-element-raw {
+  font-size: 0.8em;
+  line-height: 1.2em;
+  white-space: pre-wrap;
+  word-break: break-all;
+  margin-top: 0;
+}
+
+.slack-message-button {
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  outline: none;
+
+  padding: 0 8px 1px;
+  min-width: 56px;
+  height: 28px;
+  line-height: 28px;
+
+  user-select: none;
+
+  text-align: center;
+  white-space: nowrap;
+
+  &-primary {
+    color: rgb(0, 122, 90, 0.3);
+    border-color: rgb(0, 122, 90, 0.3);
+  }
+
+  &-danger {
+    color: rgb(210, 50, 50, 0.3);
+    border-color: rgb(210, 50, 50, 0.3);
+  }
+}

--- a/viewer/front/components/message/MrkdwnText.js
+++ b/viewer/front/components/message/MrkdwnText.js
@@ -69,14 +69,16 @@ class MrkdwnText extends React.Component {
       return `:${name}:`;
     };
     if (text) {
-      return text.replace(/<#([0-9A-Za-z]+)>/, (m, id) => channelLink(id))
+      return text
+        .replace(/<#([0-9A-Za-z]+)>/, (m, id) => channelLink(id))
         .replace(/<#([0-9A-Za-z]+)\|([0-9A-Za-z]+)>/gi, (m, id) => channelLink(id))
         .replace(/<@([0-9A-Za-z]+)>/gi, (m, id) => userLink(id))
         .replace(/<@([0-9A-Za-z]+)\|([0-9A-Za-z]+)>/gi, (m, id) => userLink(id))
         .replace(/<!(channel|everyone|group)>/gi, (m, command) => specialCommand(command))
         .replace(/<(https?:\/\/[^>|]*)\|(.+?)>/gi, (m, uri, text) => uriLink(entity(uri), entity(text)))
         .replace(/<(https?:\/\/[^>|]*)>/gi, (m, uri) => uriLink(entity(uri), entity(uri)))
-        .replace(emojiRegex, (m, name) => emojiImage(name));
+        .replace(emojiRegex, (m, name) => emojiImage(name))
+        .replace(/[*＊](.+?)[*＊]/gi, (m, text) => `<strong>${text}</strong>`);
     }
     return text;
   }


### PR DESCRIPTION
Official Reference: https://api.slack.com/reference/block-kit/blocks#section

デスクトップ

![image](https://github.com/tyage/slack-patron/assets/3126484/7cb54228-e60b-4300-88b3-519ac7b52002)

モバイル

![image](https://github.com/tyage/slack-patron/assets/3126484/7cc3fe17-f990-4838-8613-0417ca8a3ce4)
