### PR TITLE
Ruby 3.4 で標準インストールされなくなったbase64とbigdecimalジェムをGemfileに追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,3 +17,7 @@ gem "async-websocket", '~> 0.8.0' # dependency of slack-ruby-client RTM
 gem "rack", "~> 2.2"
 
 gem 'wdm', '>= 0.1.0', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem "base64", "~> 0.3.0"
+
+gem "bigdecimal", "~> 3.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1236,6 +1236,8 @@ GEM
     aws-sigv2 (1.1.0)
     aws-sigv4 (1.4.0)
       aws-eventstream (~> 1, >= 1.0.2)
+    base64 (0.3.0)
+    bigdecimal (3.2.2)
     bson (4.14.1)
     console (1.15.3)
       fiber-local
@@ -1306,6 +1308,8 @@ PLATFORMS
 DEPENDENCIES
   async-websocket (~> 0.8.0)
   aws-sdk
+  base64 (~> 0.3.0)
+  bigdecimal (~> 3.2)
   json
   mongo
   nokogiri


### PR DESCRIPTION
```
bundle add base64
bundle add bigdecimal
```

https://www.ruby-lang.org/ja/news/2024/12/25/ruby-3-4-0-released/#:~:text=新たに以下の%20gem%20が%20default%20gems%20から%20bundled%20gems%20に変更されました。