### PR TITLE
Slack API の conversations.history および conversations.replies の互換APIを作成

### DIFF
--- a/lib/api_helpers.rb
+++ b/lib/api_helpers.rb
@@ -1,0 +1,74 @@
+require 'base64'
+require './lib/db'
+
+module ApiHelpers
+  extend self
+
+  def encode_cursor(ts, direction = 'before')
+    Base64.encode64("#{direction}:#{ts}").strip
+  end
+
+  def decode_cursor(cursor)
+    return nil, nil if cursor.nil? || cursor.empty?
+    decoded = Base64.decode64(cursor)
+    parts = decoded.split(':', 2)
+    return nil, nil if parts.length != 2
+    [parts[0], parts[1]]
+  rescue
+    [nil, nil]
+  end
+
+  def validate_channel_id(channel)
+    return false if channel.nil? || channel.empty?
+    # Basic validation for Slack channel ID format
+    channel.match?(/^[CDG][A-Z0-9]{8,10}$/) || channel.match?(/^[CDG][A-Z0-9]{8,10}[A-Z0-9]*$/)
+  end
+
+  def validate_timestamp(ts)
+    return false if ts.nil? || ts.empty?
+    # Validate Slack timestamp format (Unix timestamp with microsecond precision)
+    ts.match?(/^\d+\.\d+$/)
+  end
+
+  def transform_message_to_slack_format(msg)
+    msg = normalize_message(msg)
+
+    slack_msg = {
+      'type' => msg['type'] || 'message',
+      'ts' => msg['ts']
+    }
+
+    # Add user field
+    slack_msg['user'] = msg['user'] if msg['user']
+    slack_msg['bot_id'] = msg['bot_id'] if msg['bot_id']
+
+    # Add text field
+    slack_msg['text'] = msg['text'] if msg['text']
+
+    # Add thread info
+    slack_msg['thread_ts'] = msg['thread_ts'] if msg['thread_ts']
+    slack_msg['reply_count'] = msg['reply_count'] if msg['reply_count']
+
+    # Add subtype
+    slack_msg['subtype'] = msg['subtype'] if msg['subtype']
+
+    # Add attachments
+    slack_msg['attachments'] = msg['attachments'] if msg['attachments']
+
+    # Add files
+    slack_msg['files'] = msg['files'] if msg['files']
+
+    # Add reactions
+    slack_msg['reactions'] = msg['reactions'] if msg['reactions']
+
+    # Add edited info
+    slack_msg['edited'] = msg['edited'] if msg['edited']
+
+    # Add any other Slack-specific fields that might exist
+    %w[username bot_profile app_id team blocks].each do |field|
+      slack_msg[field] = msg[field] if msg[field]
+    end
+
+    slack_msg
+  end
+end

--- a/lib/slack_api.rb
+++ b/lib/slack_api.rb
@@ -132,4 +132,149 @@ module SlackApi
       { status: 500, body: { ok: false, error: 'internal_error' } }
     end
   end
+
+  def conversations_replies_query(params)
+    limit = [params[:limit].to_i, 1000].min
+    limit = 100 if limit <= 0
+
+    channel = params[:channel]
+    ts = params[:ts]
+    oldest = params[:oldest]
+    latest = params[:latest]
+    inclusive = params[:inclusive] == 'true' || params[:inclusive] == '1'
+    cursor = params[:cursor]
+
+    # Decode cursor for pagination
+    cursor_direction, cursor_ts = ApiHelpers.decode_cursor(cursor)
+
+    # Find the thread parent message to verify it exists
+    parent_message = Messages.find({
+      channel: channel,
+      ts: ts
+    }).first
+
+    unless parent_message
+      return nil, false, nil, 'thread_not_found'
+    end
+
+    # Get the thread_ts - it's either the message's thread_ts or its own ts if it's a parent
+    thread_ts = parent_message['thread_ts'] || parent_message['ts']
+
+    conditions = [
+      { '$or' => [{ hidden: { '$ne' => true } }, { subtype: 'tombstone' }] },
+      { channel: channel },
+      # Get all messages in the thread (including the parent)
+      {
+        '$or' => [
+          { ts: thread_ts },  # The parent message
+          { thread_ts: thread_ts }  # All replies in the thread
+        ]
+      }
+    ]
+
+    # Apply timestamp filters
+    if oldest && ApiHelpers.validate_timestamp(oldest)
+      operator = inclusive ? '$gte' : '$gt'
+      conditions << { ts: { operator => oldest } }
+    end
+
+    if latest && ApiHelpers.validate_timestamp(latest)
+      operator = inclusive ? '$lte' : '$lt'
+      conditions << { ts: { operator => latest } }
+    end
+
+    # Apply cursor-based pagination
+    if cursor_ts && ApiHelpers.validate_timestamp(cursor_ts)
+      if cursor_direction == 'before'
+        conditions << { ts: { '$lt' => cursor_ts } }
+      elsif cursor_direction == 'after'
+        conditions << { ts: { '$gt' => cursor_ts } }
+      end
+    end
+
+    # Query messages
+    all_messages = Messages
+      .find({ '$and' => conditions })
+      .sort(ts: 1)  # Chronological order for thread replies
+      .limit(limit + 1)  # Get one extra to check for has_more
+      .to_a
+
+    has_more = all_messages.length > limit
+    return_messages = all_messages.first(limit)
+
+    # Generate next cursor if there are more messages
+    next_cursor = nil
+    if has_more && !return_messages.empty?
+      last_ts = return_messages.last['ts']
+      next_cursor = ApiHelpers.encode_cursor(last_ts, 'after')
+    end
+
+    # Transform messages to match Slack API format
+    slack_messages = return_messages.map do |msg|
+      ApiHelpers.transform_message_to_slack_format(msg)
+    end
+
+    return slack_messages, has_more, next_cursor, nil
+  end
+
+  def conversations_replies_response(params)
+    # Validate required parameters
+    unless params[:channel] && ApiHelpers.validate_channel_id(params[:channel])
+      return { status: 400, body: { ok: false, error: 'channel_not_found' } }
+    end
+
+    unless params[:ts] && ApiHelpers.validate_timestamp(params[:ts])
+      return { status: 400, body: { ok: false, error: 'thread_not_found' } }
+    end
+
+    # Validate optional timestamp parameters
+    if params[:oldest] && !ApiHelpers.validate_timestamp(params[:oldest])
+      return { status: 400, body: { ok: false, error: 'invalid_ts_oldest' } }
+    end
+
+    if params[:latest] && !ApiHelpers.validate_timestamp(params[:latest])
+      return { status: 400, body: { ok: false, error: 'invalid_ts_latest' } }
+    end
+
+    # Validate cursor
+    if params[:cursor]
+      direction, ts = ApiHelpers.decode_cursor(params[:cursor])
+      if direction.nil? || ts.nil?
+        return { status: 400, body: { ok: false, error: 'invalid_cursor' } }
+      end
+    end
+
+    begin
+      messages, has_more, next_cursor, error = conversations_replies_query({
+        channel: params[:channel],
+        ts: params[:ts],
+        oldest: params[:oldest],
+        latest: params[:latest],
+        inclusive: params[:inclusive],
+        cursor: params[:cursor],
+        limit: params[:limit] || 100
+      })
+
+      if error
+        return { status: 400, body: { ok: false, error: error } }
+      end
+
+      response = {
+        ok: true,
+        messages: messages,
+        has_more: has_more
+      }
+
+      # Add response_metadata with next_cursor if pagination is needed
+      if next_cursor
+        response[:response_metadata] = {
+          next_cursor: next_cursor
+        }
+      end
+
+      { status: 200, body: response }
+    rescue => e
+      { status: 500, body: { ok: false, error: 'internal_error' } }
+    end
+  end
 end

--- a/lib/slack_api.rb
+++ b/lib/slack_api.rb
@@ -1,0 +1,135 @@
+require './lib/api_helpers'
+require './lib/db'
+
+# API module that aims to mimic Slack's API endpoint
+module SlackApi
+  extend self
+
+  def conversations_history_query(params)
+    limit = [params[:limit].to_i, 1000].min
+    limit = 100 if limit <= 0
+
+    channel = params[:channel]
+    oldest = params[:oldest]
+    latest = params[:latest]
+    inclusive = params[:inclusive] == 'true' || params[:inclusive] == '1'
+    cursor = params[:cursor]
+
+    # Decode cursor for pagination
+    cursor_direction, cursor_ts = ApiHelpers.decode_cursor(cursor)
+
+    conditions = [
+      { '$or' => [{ hidden: { '$ne' => true } }, { subtype: 'tombstone' }] },
+      { channel: channel },
+      # Exclude thread-only messages
+      {
+        '$or' => [
+          { thread_ts: { '$exists' => false } },  # No thread_ts field
+          { thread_ts: nil },                     # thread_ts is null
+          { '$expr' => { '$eq' => ['$thread_ts', '$ts'] } },  # thread_ts equals ts (thread parent)
+          { subtype: 'thread_broadcast' }         # thread_broadcast messages should be shown
+        ]
+      }
+    ]
+
+    # Apply timestamp filters
+    if oldest && ApiHelpers.validate_timestamp(oldest)
+      operator = inclusive ? '$gte' : '$gt'
+      conditions << { ts: { operator => oldest } }
+    end
+
+    if latest && ApiHelpers.validate_timestamp(latest)
+      operator = inclusive ? '$lte' : '$lt'
+      conditions << { ts: { operator => latest } }
+    end
+
+    # Apply cursor-based pagination
+    if cursor_ts && ApiHelpers.validate_timestamp(cursor_ts)
+      if cursor_direction == 'before'
+        conditions << { ts: { '$lt' => cursor_ts } }
+      elsif cursor_direction == 'after'
+        conditions << { ts: { '$gt' => cursor_ts } }
+      end
+    end
+
+    # Query messages
+    all_messages = Messages
+      .find({ '$and' => conditions })
+      .sort(ts: -1)  # Most recent first, as per Slack API
+      .limit(limit + 1)  # Get one extra to check for has_more
+      .to_a
+
+    has_more = all_messages.length > limit
+    return_messages = all_messages.first(limit)
+
+    # Generate next cursor if there are more messages
+    next_cursor = nil
+    if has_more && !return_messages.empty?
+      last_ts = return_messages.last['ts']
+      next_cursor = ApiHelpers.encode_cursor(last_ts, 'before')
+    end
+
+    # Transform messages to match Slack API format
+    slack_messages = return_messages.map do |msg|
+      ApiHelpers.transform_message_to_slack_format(msg)
+    end
+
+    return slack_messages, has_more, next_cursor
+  end
+
+  def conversations_history_response(params)
+    # Validate required parameters
+    unless params[:channel] && ApiHelpers.validate_channel_id(params[:channel])
+      return { status: 400, body: { ok: false, error: 'channel_not_found' } }
+    end
+
+    # Validate optional timestamp parameters
+    if params[:oldest] && !ApiHelpers.validate_timestamp(params[:oldest])
+      return { status: 400, body: { ok: false, error: 'invalid_ts_oldest' } }
+    end
+
+    if params[:latest] && !ApiHelpers.validate_timestamp(params[:latest])
+      return { status: 400, body: { ok: false, error: 'invalid_ts_latest' } }
+    end
+
+    # Validate cursor
+    if params[:cursor]
+      direction, ts = ApiHelpers.decode_cursor(params[:cursor])
+      if direction.nil? || ts.nil?
+        return { status: 400, body: { ok: false, error: 'invalid_cursor' } }
+      end
+    end
+
+    begin
+      messages, has_more, next_cursor = conversations_history_query({
+        channel: params[:channel],
+        oldest: params[:oldest],
+        latest: params[:latest],
+        inclusive: params[:inclusive],
+        cursor: params[:cursor],
+        limit: params[:limit] || 100
+      })
+
+      response = {
+        ok: true,
+        messages: messages,
+        has_more: has_more,
+        pin_count: 0  # Not implemented
+      }
+
+      # Add response_metadata with next_cursor if pagination is needed
+      if next_cursor
+        response[:response_metadata] = {
+          next_cursor: next_cursor
+        }
+      end
+
+      # Add latest timestamp if it was provided in the request
+      response[:latest] = params[:latest] if params[:latest]
+
+      { status: 200, body: response }
+    rescue => e
+      { status: 500, body: { ok: false, error: 'internal_error' } }
+    end
+  end
+end

--- a/viewer/viewer.rb
+++ b/viewer/viewer.rb
@@ -309,3 +309,12 @@ post '/api/conversations.history' do
   
   halt result[:status], result[:body].to_json
 end
+
+# API endpoint to mimic Slack's conversations.replies method
+post '/api/conversations.replies' do
+  content_type :json
+  
+  result = SlackApi.conversations_replies_response(params)
+  
+  halt result[:status], result[:body].to_json
+end

--- a/viewer/viewer.rb
+++ b/viewer/viewer.rb
@@ -6,6 +6,7 @@ require './lib/config'
 require './lib/slack_import'
 require './lib/slack'
 require './lib/db'
+require './lib/slack_api'
 
 $config = SlackPatronConfig.config
 $signer = nil
@@ -298,4 +299,13 @@ post '/search' do
     messages: all_messages,
     has_more_message: has_more_message,
   }.to_json
+end
+
+# API endpoint to mimic Slack's conversations.history method
+post '/api/conversations.history' do
+  content_type :json
+  
+  result = SlackApi.conversations_history_response(params)
+  
+  halt result[:status], result[:body].to_json
 end


### PR DESCRIPTION
Fixes #61.

2025年9月2日から、conversations.historyおよびconversations.repliesの呼び出し回数が1分に1回に制限されることを受け、slack-patron上にこれらとの互換性の高いAPIエンドポイントを作成した。

https://api.slack.com/changelog/2025-05-terms-rate-limit-update-and-faq

めんどくさいのでコードは8割がた Claude Code くんに書いてもらいました。